### PR TITLE
Prevent VSCode from creating undo points.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "12.0.7",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.7.tgz",
-            "integrity": "sha512-1YKeT4JitGgE4SOzyB9eMwO0nGVNkNEsm9qlIt1Lqm/tG2QEiSMTD4kS3aO6L+w5SClLVxALmIBESK6Mk5wX0A==",
+            "version": "12.12.12",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.12.tgz",
+            "integrity": "sha512-MGuvYJrPU0HUwqF7LqvIj50RZUX23Z+m583KBygKYUZLlZ88n6w28XRNJRJgsHukLEnLz6w6SvxZoLgbr5wLqQ==",
             "dev": true
         },
         "agent-base": {
@@ -26,9 +26,9 @@
             }
         },
         "ajv": {
-            "version": "6.10.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-            "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+            "version": "6.10.2",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+            "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
             "dev": true,
             "requires": {
                 "fast-deep-equal": "^2.0.1",
@@ -126,9 +126,9 @@
             }
         },
         "browser-stdout": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-            "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+            "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
             "dev": true
         },
         "buffer-from": {
@@ -160,12 +160,6 @@
                 "supports-color": "^5.3.0"
             },
             "dependencies": {
-                "has-flag": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-                    "dev": true
-                },
                 "supports-color": {
                     "version": "5.5.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -178,21 +172,43 @@
             }
         },
         "cliui": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-            "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+            "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
             "dev": true,
             "requires": {
-                "string-width": "^2.1.1",
-                "strip-ansi": "^4.0.0",
-                "wrap-ansi": "^2.0.0"
+                "string-width": "^3.1.0",
+                "strip-ansi": "^5.2.0",
+                "wrap-ansi": "^5.1.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^7.0.1",
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^5.1.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                }
             }
-        },
-        "code-point-at": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-            "dev": true
         },
         "color-convert": {
             "version": "1.9.3",
@@ -219,9 +235,9 @@
             }
         },
         "commander": {
-            "version": "2.11.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-            "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+            "version": "2.15.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+            "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
             "dev": true
         },
         "concat-map": {
@@ -236,19 +252,6 @@
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
             "dev": true
         },
-        "cross-spawn": {
-            "version": "6.0.5",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-            "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-            "dev": true,
-            "requires": {
-                "nice-try": "^1.0.4",
-                "path-key": "^2.0.1",
-                "semver": "^5.5.0",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
-            }
-        },
         "dashdash": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -259,12 +262,12 @@
             }
         },
         "debug": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-            "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+            "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
             "dev": true,
             "requires": {
-                "ms": "2.0.0"
+                "ms": "^2.1.1"
             }
         },
         "decamelize": {
@@ -310,33 +313,28 @@
             "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
             "dev": true
         },
-        "end-of-stream": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-            "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-            "dev": true,
-            "requires": {
-                "once": "^1.4.0"
-            }
-        },
         "es-abstract": {
-            "version": "1.13.0",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
-            "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.0.tgz",
+            "integrity": "sha512-xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==",
             "dev": true,
             "requires": {
                 "es-to-primitive": "^1.2.0",
                 "function-bind": "^1.1.1",
                 "has": "^1.0.3",
+                "has-symbols": "^1.0.0",
                 "is-callable": "^1.1.4",
                 "is-regex": "^1.0.4",
-                "object-keys": "^1.0.12"
+                "object-inspect": "^1.6.0",
+                "object-keys": "^1.1.1",
+                "string.prototype.trimleft": "^2.1.0",
+                "string.prototype.trimright": "^2.1.0"
             }
         },
         "es-to-primitive": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
-            "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+            "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
             "dev": true,
             "requires": {
                 "is-callable": "^1.1.4",
@@ -370,21 +368,6 @@
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
             "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
             "dev": true
-        },
-        "execa": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-            "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-            "dev": true,
-            "requires": {
-                "cross-spawn": "^6.0.0",
-                "get-stream": "^4.0.0",
-                "is-stream": "^1.1.0",
-                "npm-run-path": "^2.0.0",
-                "p-finally": "^1.0.0",
-                "signal-exit": "^3.0.0",
-                "strip-eof": "^1.0.0"
-            }
         },
         "extend": {
             "version": "3.0.2",
@@ -463,15 +446,6 @@
             "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
             "dev": true
         },
-        "get-stream": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-            "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-            "dev": true,
-            "requires": {
-                "pump": "^3.0.0"
-            }
-        },
         "getpass": {
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -482,9 +456,9 @@
             }
         },
         "glob": {
-            "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-            "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+            "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
             "dev": true,
             "requires": {
                 "fs.realpath": "^1.0.0",
@@ -527,21 +501,21 @@
             }
         },
         "has-flag": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-            "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
             "dev": true
         },
         "has-symbols": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-            "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+            "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
             "dev": true
         },
         "he": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-            "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+            "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
             "dev": true
         },
         "http-proxy-agent": {
@@ -552,6 +526,23 @@
             "requires": {
                 "agent-base": "4",
                 "debug": "3.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                }
             }
         },
         "http-signature": {
@@ -566,12 +557,12 @@
             }
         },
         "https-proxy-agent": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-            "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+            "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
             "dev": true,
             "requires": {
-                "agent-base": "^4.1.0",
+                "agent-base": "^4.3.0",
                 "debug": "^3.1.0"
             }
         },
@@ -586,21 +577,15 @@
             }
         },
         "inherits": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-            "dev": true
-        },
-        "invert-kv": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-            "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "dev": true
         },
         "is-buffer": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-            "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+            "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
             "dev": true
         },
         "is-callable": {
@@ -630,19 +615,13 @@
                 "has": "^1.0.1"
             }
         },
-        "is-stream": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-            "dev": true
-        },
         "is-symbol": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
-            "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+            "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
             "dev": true,
             "requires": {
-                "has-symbols": "^1.0.0"
+                "has-symbols": "^1.0.1"
             }
         },
         "is-typedarray": {
@@ -709,15 +688,6 @@
                 "verror": "1.10.0"
             }
         },
-        "lcid": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-            "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
-            "dev": true,
-            "requires": {
-                "invert-kv": "^2.0.0"
-            }
-        },
         "locate-path": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -729,9 +699,9 @@
             }
         },
         "lodash": {
-            "version": "4.17.11",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-            "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+            "version": "4.17.15",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+            "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
             "dev": true
         },
         "log-symbols": {
@@ -743,46 +713,20 @@
                 "chalk": "^2.0.1"
             }
         },
-        "map-age-cleaner": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-            "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-            "dev": true,
-            "requires": {
-                "p-defer": "^1.0.0"
-            }
-        },
-        "mem": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
-            "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
-            "dev": true,
-            "requires": {
-                "map-age-cleaner": "^0.1.1",
-                "mimic-fn": "^2.0.0",
-                "p-is-promise": "^2.0.0"
-            }
-        },
         "mime-db": {
-            "version": "1.40.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-            "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
+            "version": "1.42.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.42.0.tgz",
+            "integrity": "sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ==",
             "dev": true
         },
         "mime-types": {
-            "version": "2.1.24",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
-            "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+            "version": "2.1.25",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.25.tgz",
+            "integrity": "sha512-5KhStqB5xpTAeGqKBAMgwaYMnQik7teQN4IAzC7npDv6kzeU6prfkR67bc87J1kWMPGkoaZSq1npmexMgkmEVg==",
             "dev": true,
             "requires": {
-                "mime-db": "1.40.0"
+                "mime-db": "1.42.0"
             }
-        },
-        "mimic-fn": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-            "dev": true
         },
         "minimatch": {
             "version": "3.0.4",
@@ -809,9 +753,9 @@
             }
         },
         "mocha": {
-            "version": "6.1.4",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.1.4.tgz",
-            "integrity": "sha512-PN8CIy4RXsIoxoFJzS4QNnCH4psUCPWc4/rPrst/ecSJJbLBkubMiyGCP2Kj/9YnWbotFqAoeXyXMucj7gwCFg==",
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.2.tgz",
+            "integrity": "sha512-FgDS9Re79yU1xz5d+C4rv1G7QagNGHZ+iXF81hO8zY35YZZcLEsJVfFolfsqKFWunATEvNzMK0r/CwWd/szO9A==",
             "dev": true,
             "requires": {
                 "ansi-colors": "3.2.3",
@@ -834,64 +778,15 @@
                 "supports-color": "6.0.0",
                 "which": "1.3.1",
                 "wide-align": "1.1.3",
-                "yargs": "13.2.2",
-                "yargs-parser": "13.0.0",
-                "yargs-unparser": "1.5.0"
-            },
-            "dependencies": {
-                "browser-stdout": {
-                    "version": "1.3.1",
-                    "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-                    "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-                    "dev": true
-                },
-                "debug": {
-                    "version": "3.2.6",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
-                "glob": {
-                    "version": "7.1.3",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-                    "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-                    "dev": true,
-                    "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
-                    }
-                },
-                "he": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-                    "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-                    "dev": true
-                },
-                "ms": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-                    "dev": true
-                }
+                "yargs": "13.3.0",
+                "yargs-parser": "13.1.1",
+                "yargs-unparser": "1.6.0"
             }
         },
         "ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-            "dev": true
-        },
-        "nice-try": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-            "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+            "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
             "dev": true
         },
         "node-environment-flags": {
@@ -904,25 +799,16 @@
                 "semver": "^5.7.0"
             }
         },
-        "npm-run-path": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-            "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-            "dev": true,
-            "requires": {
-                "path-key": "^2.0.0"
-            }
-        },
-        "number-is-nan": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-            "dev": true
-        },
         "oauth-sign": {
             "version": "0.9.0",
             "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
             "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+            "dev": true
+        },
+        "object-inspect": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+            "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
             "dev": true
         },
         "object-keys": {
@@ -962,39 +848,10 @@
                 "wrappy": "1"
             }
         },
-        "os-locale": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
-            "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
-            "dev": true,
-            "requires": {
-                "execa": "^1.0.0",
-                "lcid": "^2.0.0",
-                "mem": "^4.0.0"
-            }
-        },
-        "p-defer": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-            "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
-            "dev": true
-        },
-        "p-finally": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-            "dev": true
-        },
-        "p-is-promise": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
-            "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
-            "dev": true
-        },
         "p-limit": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-            "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+            "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
             "dev": true,
             "requires": {
                 "p-try": "^2.0.0"
@@ -1027,12 +884,6 @@
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
             "dev": true
         },
-        "path-key": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-            "dev": true
-        },
         "performance-now": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -1040,20 +891,10 @@
             "dev": true
         },
         "psl": {
-            "version": "1.1.32",
-            "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.32.tgz",
-            "integrity": "sha512-MHACAkHpihU/REGGPLj4sEfc/XKW2bheigvHO1dUqjaKigMp1C8+WLQYRGgeKFMsw5PMfegZcaN8IDXK/cD0+g==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
+            "integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==",
             "dev": true
-        },
-        "pump": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-            "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-            "dev": true,
-            "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
-            }
         },
         "punycode": {
             "version": "2.1.1",
@@ -1126,9 +967,9 @@
             "dev": true
         },
         "safe-buffer": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+            "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
             "dev": true
         },
         "safer-buffer": {
@@ -1138,36 +979,15 @@
             "dev": true
         },
         "semver": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-            "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
             "dev": true
         },
         "set-blocking": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
             "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-            "dev": true
-        },
-        "shebang-command": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-            "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-            "dev": true,
-            "requires": {
-                "shebang-regex": "^1.0.0"
-            }
-        },
-        "shebang-regex": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-            "dev": true
-        },
-        "signal-exit": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
             "dev": true
         },
         "source-map": {
@@ -1177,9 +997,9 @@
             "dev": true
         },
         "source-map-support": {
-            "version": "0.5.12",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
-            "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+            "version": "0.5.16",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
+            "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
             "dev": true,
             "requires": {
                 "buffer-from": "^1.0.0",
@@ -1219,6 +1039,26 @@
                 "strip-ansi": "^4.0.0"
             }
         },
+        "string.prototype.trimleft": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
+            "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.3",
+                "function-bind": "^1.1.1"
+            }
+        },
+        "string.prototype.trimright": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
+            "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.3",
+                "function-bind": "^1.1.1"
+            }
+        },
         "strip-ansi": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -1227,12 +1067,6 @@
             "requires": {
                 "ansi-regex": "^3.0.0"
             }
-        },
-        "strip-eof": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-            "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-            "dev": true
         },
         "strip-json-comments": {
             "version": "2.0.1",
@@ -1247,14 +1081,6 @@
             "dev": true,
             "requires": {
                 "has-flag": "^3.0.0"
-            },
-            "dependencies": {
-                "has-flag": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-                    "dev": true
-                }
             }
         },
         "tough-cookie": {
@@ -1291,9 +1117,9 @@
             "dev": true
         },
         "typescript": {
-            "version": "3.5.1",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.1.tgz",
-            "integrity": "sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==",
+            "version": "3.7.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",
+            "integrity": "sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==",
             "dev": true
         },
         "uri-js": {
@@ -1316,9 +1142,9 @@
             }
         },
         "uuid": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+            "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
             "dev": true
         },
         "verror": {
@@ -1333,13 +1159,13 @@
             }
         },
         "vscode": {
-            "version": "1.1.34",
-            "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.34.tgz",
-            "integrity": "sha512-GuT3tCT2N5Qp26VG4C+iGmWMgg/MuqtY5G5TSOT3U/X6pgjM9LFulJEeqpyf6gdzpI4VyU3ZN/lWPo54UFPuQg==",
+            "version": "1.1.36",
+            "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.36.tgz",
+            "integrity": "sha512-cGFh9jmGLcTapCpPCKvn8aG/j9zVQ+0x5hzYJq5h5YyUXVGa1iamOaB2M2PZXoumQPES4qeAP1FwkI0b6tL4bQ==",
             "dev": true,
             "requires": {
                 "glob": "^7.1.2",
-                "mocha": "^4.0.1",
+                "mocha": "^5.2.0",
                 "request": "^2.88.0",
                 "semver": "^5.4.1",
                 "source-map-support": "^0.5.0",
@@ -1347,34 +1173,38 @@
                 "vscode-test": "^0.4.1"
             },
             "dependencies": {
-                "diff": {
-                    "version": "3.3.1",
-                    "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-                    "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
-                    "dev": true
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
                 },
-                "growl": {
-                    "version": "1.10.3",
-                    "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-                    "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+                "he": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+                    "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
                     "dev": true
                 },
                 "mocha": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
-                    "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+                    "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
                     "dev": true,
                     "requires": {
-                        "browser-stdout": "1.3.0",
-                        "commander": "2.11.0",
+                        "browser-stdout": "1.3.1",
+                        "commander": "2.15.1",
                         "debug": "3.1.0",
-                        "diff": "3.3.1",
+                        "diff": "3.5.0",
                         "escape-string-regexp": "1.0.5",
                         "glob": "7.1.2",
-                        "growl": "1.10.3",
+                        "growl": "1.10.5",
                         "he": "1.1.1",
+                        "minimatch": "3.0.4",
                         "mkdirp": "0.5.1",
-                        "supports-color": "4.4.0"
+                        "supports-color": "5.4.0"
                     },
                     "dependencies": {
                         "glob": {
@@ -1393,13 +1223,19 @@
                         }
                     }
                 },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                },
                 "supports-color": {
-                    "version": "4.4.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-                    "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^2.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -1439,48 +1275,40 @@
             }
         },
         "wrap-ansi": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-            "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+            "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
             "dev": true,
             "requires": {
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1"
+                "ansi-styles": "^3.2.0",
+                "string-width": "^3.0.0",
+                "strip-ansi": "^5.0.0"
             },
             "dependencies": {
                 "ansi-regex": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
                     "dev": true
                 },
-                "is-fullwidth-code-point": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                    "dev": true,
-                    "requires": {
-                        "number-is-nan": "^1.0.0"
-                    }
-                },
                 "string-width": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
                     "dev": true,
                     "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
+                        "emoji-regex": "^7.0.1",
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^5.1.0"
                     }
                 },
                 "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^2.0.0"
+                        "ansi-regex": "^4.1.0"
                     }
                 }
             }
@@ -1498,22 +1326,21 @@
             "dev": true
         },
         "yargs": {
-            "version": "13.2.2",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.2.tgz",
-            "integrity": "sha512-WyEoxgyTD3w5XRpAQNYUB9ycVH/PQrToaTXdYXRdOXvEy1l19br+VJsc0vcO8PTGg5ro/l/GY7F/JMEBmI0BxA==",
+            "version": "13.3.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
+            "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
             "dev": true,
             "requires": {
-                "cliui": "^4.0.0",
+                "cliui": "^5.0.0",
                 "find-up": "^3.0.0",
                 "get-caller-file": "^2.0.1",
-                "os-locale": "^3.1.0",
                 "require-directory": "^2.1.1",
                 "require-main-filename": "^2.0.0",
                 "set-blocking": "^2.0.0",
                 "string-width": "^3.0.0",
                 "which-module": "^2.0.0",
                 "y18n": "^4.0.0",
-                "yargs-parser": "^13.0.0"
+                "yargs-parser": "^13.1.1"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -1545,9 +1372,9 @@
             }
         },
         "yargs-parser": {
-            "version": "13.0.0",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.0.0.tgz",
-            "integrity": "sha512-w2LXjoL8oRdRQN+hOyppuXs+V/fVAYtpcrRxZuF7Kt/Oc+Jr2uAcVntaUTNT6w5ihoWfFDpNY8CPx1QskxZ/pw==",
+            "version": "13.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+            "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
             "dev": true,
             "requires": {
                 "camelcase": "^5.0.0",
@@ -1555,58 +1382,14 @@
             }
         },
         "yargs-unparser": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.5.0.tgz",
-            "integrity": "sha512-HK25qidFTCVuj/D1VfNiEndpLIeJN78aqgR23nL3y4N0U/91cOAzqfHlF8n2BvoNDcZmJKin3ddNSvOxSr8flw==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
+            "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
             "dev": true,
             "requires": {
                 "flat": "^4.1.0",
-                "lodash": "^4.17.11",
-                "yargs": "^12.0.5"
-            },
-            "dependencies": {
-                "get-caller-file": {
-                    "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-                    "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
-                    "dev": true
-                },
-                "require-main-filename": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-                    "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-                    "dev": true
-                },
-                "yargs": {
-                    "version": "12.0.5",
-                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-                    "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
-                    "dev": true,
-                    "requires": {
-                        "cliui": "^4.0.0",
-                        "decamelize": "^1.2.0",
-                        "find-up": "^3.0.0",
-                        "get-caller-file": "^1.0.1",
-                        "os-locale": "^3.0.0",
-                        "require-directory": "^2.1.1",
-                        "require-main-filename": "^1.0.1",
-                        "set-blocking": "^2.0.0",
-                        "string-width": "^2.0.0",
-                        "which-module": "^2.0.0",
-                        "y18n": "^3.2.1 || ^4.0.0",
-                        "yargs-parser": "^11.1.1"
-                    }
-                },
-                "yargs-parser": {
-                    "version": "11.1.1",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-                    "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
-                    "dev": true,
-                    "requires": {
-                        "camelcase": "^5.0.0",
-                        "decamelize": "^1.2.0"
-                    }
-                }
+                "lodash": "^4.17.15",
+                "yargs": "^13.3.0"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -69,10 +69,10 @@
   },
   "devDependencies": {
     "@types/mocha": "^5.2.7",
-    "@types/node": "^12.0.7",
-    "mocha": "^6.1.4",
+    "@types/node": "^12.12.12",
+    "mocha": "^6.2.2",
     "ramda": "^0.26.1",
-    "typescript": "^3.5.1",
-    "vscode": "^1.1.34"
+    "typescript": "^3.7.2",
+    "vscode": "^1.1.36"
   }
 }

--- a/src/smartActions.ts
+++ b/src/smartActions.ts
@@ -36,7 +36,7 @@ const queueCommand = (name: string) => (): Thenable<boolean> =>
 
 /**
 * "Unpads" bracket pairs on backspace. E.g: (| = cursor)
-* 
+*
 * ------------------------------
 * { | } + <Backspace>
 * Results in: {|}
@@ -52,11 +52,11 @@ export function smartBackspace(change: vsc.TextDocumentContentChangeEvent): Then
 
   const document = editor.document;
   const selection = editor.selection;
-  
+
   try {
     const prevChar = getAdjacentCharacters(document, selection.active, -1);
     const nextChars = getAdjacentCharacters(document, selection.active, 2);
-    
+
     if (nextChars === unpad[prevChar]) {
       return vsc.commands.executeCommand('deleteRight');
     }
@@ -84,16 +84,16 @@ export function smartSpace(change: vsc.TextDocumentContentChangeEvent): Thenable
   }
 
   const document = editor.document;
-  
+
   try {
     const cursorPriorToChange = change.range.start;
     const cursorAfterChange = change.range.start.translate(0, 1);
 
     const prevChars = getAdjacentCharacters(document, cursorAfterChange, -2);
     const nextChar = getAdjacentCharacters(document, cursorAfterChange, 1);
-    
+
     if (nextChar === pad[prevChars]) {
-      return editor.edit(insert(cursorPriorToChange, ' '))
+      return editor.edit(insert(cursorPriorToChange, ' '), { undoStopAfter: false, undoStopBefore: false })
         .then(() => {
           editor.selection = new vsc.Selection(cursorAfterChange, cursorAfterChange);
           return true;
@@ -108,7 +108,7 @@ export function smartSpace(change: vsc.TextDocumentContentChangeEvent): Thenable
 
 /**
 * Closes bracket pairs when applicable. E.g: (| = cursor)
-* 
+*
 * ------------------------------
 * { foo: 'bar'| } + <}>
 * Results in: { foo: 'bar' }|
@@ -157,7 +157,8 @@ export function smartClose(change: vsc.TextDocumentContentChangeEvent): Thenable
   }
 
   return editor.edit(edit =>
-    edit.delete(new vsc.Range(change.range.start, change.range.start.translate(0, 1)))
+    edit.delete(new vsc.Range(change.range.start, change.range.start.translate(0, 1))),
+    { undoStopAfter: false, undoStopBefore: false }
   ).then(() => {
     const position = change.range.start.translate(0, 2);
     editor.selection = new vsc.Selection(position, position);


### PR DESCRIPTION
VSCode was creating undo stops around the extension's edit commands and breaking the undo history. This change sets options on `TextEditor#edit` to prevent additional stops from being created.